### PR TITLE
Improve Telegram polling diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,32 @@ yarn
 cp .env.example .env
 ```
 
-3. Build and start:
+If the bot runs on a host with broken IPv6 connectivity to Telegram, set:
+```bash
+TELEGRAM_IP_FAMILY=4
+```
+
+3. Start local PostgreSQL:
+```bash
+docker compose -f docker-compose.db.yml up -d
+```
+
+Check status:
+```bash
+docker compose -f docker-compose.db.yml ps
+```
+
+Stop DB:
+```bash
+docker compose -f docker-compose.db.yml down
+```
+
+Reset DB data:
+```bash
+docker compose -f docker-compose.db.yml down -v
+```
+
+4. Build and start:
 ```bash
 yarn build
 yarn start

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,9 +7,10 @@ import { buildCallbackData, CallbackAction } from "@root/telegram/callback-data"
 dotenv.config()
 
 const envVarsSchema = Joi.object({
-  TELEGRAM_TOKEN: Joi.string().description("Telegram token"),
-  SYSTEM_TELEGRAM_TOKEN: Joi.string().description("System telegram token"),
-  SYSTEM_TELEGRAM_CHAT_ID: Joi.string().description("System telegram chat id"),
+  TELEGRAM_TOKEN: Joi.string().trim().required().description("Telegram token"),
+  SYSTEM_TELEGRAM_TOKEN: Joi.string().trim().allow("").default("").description("System telegram token"),
+  SYSTEM_TELEGRAM_CHAT_ID: Joi.string().trim().allow("").default("").description("System telegram chat id"),
+  TELEGRAM_IP_FAMILY: Joi.number().valid(4, 6).optional().description("Force Telegram API IPv4 or IPv6"),
 
   PSQL_HOST: Joi.string().default("localhost").description("Database Host"),
   PSQL_DATABASE: Joi.string().default("database").description("Database Name"),
@@ -21,6 +22,15 @@ const envVarsSchema = Joi.object({
 
 const { error, value: envVars } = envVarsSchema.validate(process.env, { allowUnknown: true })
 if (error) throw new Error(`Config validation error: ${error.message}`)
+
+const hasSystemTelegramToken = Boolean(envVars.SYSTEM_TELEGRAM_TOKEN)
+const hasSystemTelegramChatId = Boolean(envVars.SYSTEM_TELEGRAM_CHAT_ID)
+
+if (hasSystemTelegramToken !== hasSystemTelegramChatId) {
+  throw new Error("Config validation error: SYSTEM_TELEGRAM_TOKEN and SYSTEM_TELEGRAM_CHAT_ID must be set together")
+}
+
+const isSystemTelegramEnabled = hasSystemTelegramToken && hasSystemTelegramChatId
 
 const callbackData = {
   start: CallbackAction.Start,
@@ -42,8 +52,10 @@ const callbackData = {
 
 export default {
   telegramToken: envVars.TELEGRAM_TOKEN,
-  systemTelegramToken: envVars.SYSTEM_TELEGRAM_TOKEN,
-  systemTelegramChatId: Number(envVars.SYSTEM_TELEGRAM_CHAT_ID),
+  systemTelegramToken: envVars.SYSTEM_TELEGRAM_TOKEN || null,
+  systemTelegramChatId: isSystemTelegramEnabled ? Number(envVars.SYSTEM_TELEGRAM_CHAT_ID) : null,
+  isSystemTelegramEnabled,
+  telegramIpFamily: envVars.TELEGRAM_IP_FAMILY ?? null,
 
   psqlHost: envVars.PSQL_HOST,
   psqlDatabase: envVars.PSQL_DATABASE,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import "./aliases"
 import TelegramBot from "node-telegram-bot-api"
+import type { Options } from "request"
 
 import config from "./config"
 import DbService from "@services/db"
@@ -11,8 +12,10 @@ import PromoHandler from "@root/telegram/handlers/promo-handler"
 import SystemCommandHandler from "@root/telegram/handlers/system-command-handler"
 
 class Telegram {
-  private bot = new TelegramBot(config.telegramToken, { polling: true })
-  private systemBot = new TelegramBot(config.systemTelegramToken, { polling: true })
+  private bot = new TelegramBot(config.telegramToken, this.buildBotOptions())
+  private systemBot = config.systemTelegramToken
+    ? new TelegramBot(config.systemTelegramToken, this.buildBotOptions())
+    : null
 
   private waitingPromoIds: Array<number> = []
 
@@ -22,7 +25,7 @@ class Telegram {
 
   private callbacks = new CallbackHandler(this.bot, this.db, this.messages, this.payment)
   private commands = new CommandHandler(this.messages, this.callbacks)
-  private systemCommands = new SystemCommandHandler(this.systemBot)
+  private systemCommands = this.systemBot ? new SystemCommandHandler(this.systemBot) : null
   private promo = new PromoHandler(this.bot, this.db, this.messages, this.payment, this.waitingPromoIds)
 
   private async isBlocked(userId?: number): Promise<boolean> {
@@ -32,6 +35,12 @@ class Telegram {
   }
 
   public process() {
+    this.attachBotErrorHandlers(this.bot, "main")
+
+    if (this.systemBot) {
+      this.attachBotErrorHandlers(this.systemBot, "system")
+    }
+
     this.bot.on("message", async (msg) => {
       const { from, chat, text } = msg
       if (!from || !text) return
@@ -64,7 +73,78 @@ class Telegram {
       return this.payment.successfulPayment(message)
     })
 
-    this.systemCommands.process()
+    this.systemCommands?.process()
+  }
+
+  private attachBotErrorHandlers(bot: TelegramBot, name: string) {
+    bot.on("polling_error", (error) => {
+      console.error(`[telegram:${name}] polling_error`, this.formatTelegramError(error))
+    })
+
+    bot.on("error", (error) => {
+      console.error(`[telegram:${name}] error`, this.formatTelegramError(error))
+    })
+  }
+
+  private buildBotOptions(): TelegramBot.ConstructorOptions {
+    const request = config.telegramIpFamily ? ({ family: config.telegramIpFamily } as Options) : undefined
+
+    return {
+      polling: true,
+      request
+    }
+  }
+
+  private formatTelegramError(error: unknown): unknown {
+    if (this.isAggregateError(error)) {
+      return {
+        name: error.name,
+        message: error.message,
+        code: this.readProp(error, "code"),
+        cause: this.formatTelegramError(this.readProp(error, "cause")),
+        errors: error.errors.map((item: unknown) => this.formatTelegramError(item))
+      }
+    }
+
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        code: this.readProp(error, "code"),
+        errno: this.readProp(error, "errno"),
+        syscall: this.readProp(error, "syscall"),
+        address: this.readProp(error, "address"),
+        port: this.readProp(error, "port"),
+        response: this.formatTelegramResponse(this.readProp(error, "response")),
+        cause: this.formatTelegramError(this.readProp(error, "cause")),
+        stack: error.stack
+      }
+    }
+
+    return error
+  }
+
+  private formatTelegramResponse(response: unknown): unknown {
+    if (!response || typeof response !== "object") return response
+
+    return {
+      statusCode: this.readProp(response, "statusCode"),
+      body: this.readProp(response, "body")
+    }
+  }
+
+  private readProp(value: unknown, key: string): unknown {
+    if (!value || typeof value !== "object") return undefined
+
+    return (value as Record<string, unknown>)[key]
+  }
+
+  private isAggregateError(error: unknown): error is Error & { errors: Array<unknown> } {
+    return (
+      error instanceof Error &&
+      "errors" in error &&
+      Array.isArray((error as { errors?: Array<unknown> }).errors)
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- log nested Telegram polling causes, response details, and socket metadata instead of only `EFATAL: AggregateError`
- allow forcing Telegram API IPv4 or IPv6 via `TELEGRAM_IP_FAMILY`
- document the IPv4 workaround in the local run instructions

## Testing
- yarn type